### PR TITLE
Allow images to be moved around the cropper area when zoom is less than 1

### DIFF
--- a/cypress/e2e/touch_spec.js
+++ b/cypress/e2e/touch_spec.js
@@ -57,7 +57,7 @@ describe('Touch assertions', function () {
         ],
       })
       .trigger('touchend')
-    cy.get('img').should('have.css', 'transform', 'matrix(1, 0, 0, 1, -36.8182, 0)')
+    cy.get('img').should('have.css', 'transform', 'matrix(0.99, 0, 0, 0.99, -145.667, -2.62)')
   })
 
   it('Move image with pinch based on the center between 2 fingers', function () {

--- a/src/lib/Cropper.svelte
+++ b/src/lib/Cropper.svelte
@@ -145,6 +145,18 @@
         y: dragStartCrop.y + offsetY,
       }
 
+      // Allow free movement of the image inside the crop area if zoom is less than 1
+      // But limit the image to inside the cropBox
+      if (zoom < 1) {
+        const x_limit = cropperSize.width / 2 - ((imageSize.width * zoom) / 2);
+        const y_limit = cropperSize.height / 2 - ((imageSize.height * zoom) / 2);
+
+        let new_pos_x = Math.min(x_limit, Math.max(requestedPosition.x, -x_limit));
+        let new_pos_y = Math.min(y_limit, Math.max(requestedPosition.y, -y_limit));
+        crop = {x: new_pos_x, y: new_pos_y}
+        return;
+      }
+
       crop = restrictPosition
         ? helpers.restrictPosition(requestedPosition, imageSize, cropperSize, zoom)
         : requestedPosition

--- a/src/lib/Cropper.svelte
+++ b/src/lib/Cropper.svelte
@@ -145,18 +145,6 @@
         y: dragStartCrop.y + offsetY,
       }
 
-      // Allow free movement of the image inside the crop area if zoom is less than 1
-      // But limit the image to inside the cropBox
-      if (zoom < 1) {
-        const x_limit = cropperSize.width / 2 - ((imageSize.width * zoom) / 2);
-        const y_limit = cropperSize.height / 2 - ((imageSize.height * zoom) / 2);
-
-        let new_pos_x = Math.min(x_limit, Math.max(requestedPosition.x, -x_limit));
-        let new_pos_y = Math.min(y_limit, Math.max(requestedPosition.y, -y_limit));
-        crop = {x: new_pos_x, y: new_pos_y}
-        return;
-      }
-
       crop = restrictPosition
         ? helpers.restrictPosition(requestedPosition, imageSize, cropperSize, zoom)
         : requestedPosition

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -45,7 +45,15 @@ function restrictPositionCoord(
   cropSize: number,
   zoom: number
 ) {
-  const maxPosition = (imageSize * zoom) / 2 - cropSize / 2
+  // Default max position calculation
+  let maxPosition = (imageSize * zoom) / 2 - cropSize / 2
+
+  // Allow free movement of the image inside the crop area if zoom is less than 1
+  // But limit the image's position to inside the cropBox
+  if (zoom < 1) {
+    maxPosition = cropSize / 2 - (imageSize * zoom) / 2
+  }
+
   return Math.min(maxPosition, Math.max(position, -maxPosition))
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,9 +4,18 @@
 
   let crop = { x: 0, y: 0 }
   let zoom = 1
+  let minZoom = 0.5;
+  let maxZoom = 3;
 
   const urlArgs = typeof window !== 'undefined' ? queryString.parse(window.location.search) : null
   let image = typeof urlArgs?.img === 'string' ? urlArgs.img : '/images/dog.jpeg' // so we can change the image from our tests
 </script>
 
-<Cropper {image} bind:crop bind:zoom on:cropcomplete={e => console.log(e.detail)} />
+<Cropper
+  {image}
+  bind:crop
+  bind:zoom
+  bind:minZoom
+  bind:maxZoom
+  on:cropcomplete={e => console.log(e.detail)}
+/>


### PR DESCRIPTION
I'm not sure if this is a feature you're looking for in this package, but it has been useful in projects before. Feel free to reject.

Currently when zoom goes below 1 and the image becomes smaller than the cropper area the image stays glued to the top left corner of the cropper area. This update will make it so that when zoom drops below 1 the image can be moved around in the cropper area but no part of the image can be outside of it.

Where does this idea come from? When letting users upload logos, that will be displayed in a round avatar, in a SaaS product it can be useful to let users resize the logo smaller than the cropper area to fit more nicely in the round avatar.