### PR TITLE
add nonpassive event modifier to mouse wheel and touchstart event lis…

### DIFF
--- a/src/lib/Cropper.svelte
+++ b/src/lib/Cropper.svelte
@@ -2,7 +2,7 @@
   import { createEventDispatcher, onDestroy, onMount } from 'svelte'
   import type { HTMLImgAttributes } from 'svelte/elements'
   import * as helpers from './helpers'
-  import type { Point, CropShape, Size, DispatchEvents, ImageSize } from './types'
+  import type { CropShape, DispatchEvents, ImageSize, Point, Size } from './types'
 
   export let image: string
   export let crop: Point = { x: 0, y: 0 }
@@ -250,8 +250,8 @@
   class="container"
   bind:this={containerEl}
   on:mousedown|preventDefault={onMouseDown}
-  on:touchstart|preventDefault={onTouchStart}
-  on:wheel|preventDefault={onWheel}
+  on:touchstart|nonpassive|preventDefault={onTouchStart}
+  on:wheel|nonpassive|preventDefault={onWheel}
   {tabindex}
   role="button"
   data-testid="container"


### PR DESCRIPTION
## Problem
Chrome complains of `non-passive event listener` violations if certain listeners are not *explicitly* marked as non-passive. It's kind of dumb:

<img width="612" alt="svelte-easy-crop-console" src="https://github.com/ValentinH/svelte-easy-crop/assets/682323/32ddc96e-708e-40e7-8a40-388e2b7674b3">


## Solution

We can get rid of this warning by adding the `nonpassive` event modifier like so:

``` js
 on:wheel|nonpassive|preventDefault={onWheel}
```

This PR adds two modifiers to clean up the console warnings when using `svelte-easy-crop` in Chrome. 




